### PR TITLE
Поддержка pterodactyl panel

### DIFF
--- a/packages/server/src/components/config/utils/ApiConfig.ts
+++ b/packages/server/src/components/config/utils/ApiConfig.ts
@@ -15,7 +15,7 @@ export class ApiConfig {
     static getDefaultConfig(): ApiConfig {
         return {
             host: "0.0.0.0",
-            port: 1370,
+            port: process.env.SERVER_PORT || 1370,
             useSSL: false,
             ssl: {
                 cert: "/path/to/cert.pem",


### PR DESCRIPTION
Сделал так, чтобы при установке в pterodactyl panel, порт контейнера устанавливался в конфиг автоматически